### PR TITLE
UPDATE: Page class to allow dynamic properties

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -2,6 +2,7 @@
 
 namespace Faktory;
 
+#[\AllowDynamicProperties]
 class Page
 {
 

--- a/src/Post.php
+++ b/src/Post.php
@@ -2,7 +2,6 @@
 
 namespace Faktory;
 
-#[\AllowDynamicProperties]
 class Post extends Page
 {
 }


### PR DESCRIPTION
Because:

- Page is the new default class
- All other classes inherit from that

Adds the #[\AllowDynamicProperties] attribute to the page class instead of the post class as Page is the new default class